### PR TITLE
Add multimodal OCR module for on-screen text extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ Thumbs.db
 !experiments/**/NOTES.md
 !experiments/**/results.csv
 !experiments/**/plots/**
+
+# ---- EasyOCR model cache (added for OCR module)
+.EasyOCR/
+*.pth
+
+# ---- Environment-specific documentation (user-specific)
+ENVIRONMENT_SETUP.md
+QUICKSTART.txt

--- a/experiments/_templates/README.md
+++ b/experiments/_templates/README.md
@@ -1,0 +1,80 @@
+# Experiment Templates
+
+This folder contains templates for creating new experiments.
+
+## Quick Start - Create New Experiment
+
+```bash
+# From project root
+bash experiments/_templates/create_new_experiment.sh exp-YOUR-NAME
+
+# Example:
+bash experiments/_templates/create_new_experiment.sh exp-002-fewshot-mistral
+```
+
+This will create:
+- `experiments/exp-YOUR-NAME/config.yaml` (pre-configured)
+- `experiments/exp-YOUR-NAME/NOTES.md` (structured notes template)
+- `experiments/exp-YOUR-NAME/command.txt` (exact command to run)
+
+## Manual Setup
+
+If you prefer to create experiments manually:
+
+1. **Copy template:**
+   ```bash
+   cp experiments/_templates/config.template.yaml experiments/YOUR-EXP/config.yaml
+   ```
+
+2. **Edit configuration:**
+   - Update `out:` path to match your experiment folder
+   - Choose prompt type: `baseline`, `fewshot`, or `reasoned`
+   - Set temperature (0.0 recommended for reproducibility)
+   - Add descriptive notes
+
+3. **Run experiment:**
+   ```bash
+   python scripts/run_mistral_batch.py --config experiments/YOUR-EXP/config.yaml
+   ```
+
+4. **Generate analysis:**
+   ```bash
+   python scripts/analyze_experiment.py --exp-dir experiments/YOUR-EXP
+   ```
+
+## Experiment Naming Convention
+
+Use descriptive names that indicate what you're testing:
+
+- `exp-001-mistral-baseline` - Baseline with Mistral
+- `exp-002-mistral-fewshot` - Few-shot prompting
+- `exp-003-llama-comparison` - Different model comparison
+- `exp-004-multilingual-test` - Non-English content
+- `exp-005-high-temp` - Temperature variation
+
+## Configuration Options
+
+### Prompt Types
+- **baseline**: Standard classification (fastest, consistent)
+- **fewshot**: Includes examples (better calibration)
+- **reasoned**: Chain-of-thought (slowest, most detailed)
+
+### Model Options (Ollama)
+- `mistral` - 7B params, fast, good accuracy
+- `llama2` - Meta's model, 7B-70B variants
+- `gemma` - Google's efficient model
+- `phi` - Microsoft's small but capable model
+
+### Temperature Settings
+- `0.0` - Deterministic (recommended for reproducibility)
+- `0.1-0.3` - Slightly variable but consistent
+- `0.5-0.7` - Balanced creativity
+- `1.0+` - More creative (not recommended for research)
+
+## Best Practices
+
+1. **One variable at a time**: Only change one parameter per experiment
+2. **Document everything**: Use NOTES.md to record observations
+3. **Version your data**: Note which video samples you used
+4. **Commit results**: Git commit each completed experiment
+5. **Compare systematically**: Use same videos across experiments when testing prompts/models

--- a/experiments/_templates/config.template.yaml
+++ b/experiments/_templates/config.template.yaml
@@ -1,0 +1,20 @@
+# Experiment Configuration Template
+# Copy this file to your experiment folder and customize
+
+input_dir: data/videos           # Where your test videos are located
+out: experiments/YOUR-EXP-NAME/results.csv  # Output CSV path
+prompt: baseline                 # Options: baseline | fewshot | reasoned
+model_name: mistral              # For Ollama: mistral | llama2 | gemma | etc.
+temperature: 0.0                 # 0.0 = deterministic, higher = more creative
+provider: Local                  # Local (Ollama) | OpenAI | Azure
+notes: "Brief description of experiment goals"
+
+# Prompt Types Explained:
+# - baseline: Standard classification prompt
+# - fewshot: Includes example classifications for calibration
+# - reasoned: Asks LLM to think step-by-step (may be slower)
+
+# Temperature Guidelines:
+# - 0.0: Reproducible, deterministic (recommended for experiments)
+# - 0.3-0.7: Balanced creativity
+# - 1.0+: More creative but less consistent

--- a/experiments/_templates/create_new_experiment.sh
+++ b/experiments/_templates/create_new_experiment.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Quick script to create a new experiment folder
+
+if [ -z "$1" ]; then
+    echo "Usage: ./create_new_experiment.sh <experiment-name>"
+    echo "Example: ./create_new_experiment.sh exp-002-fewshot-test"
+    exit 1
+fi
+
+EXP_NAME=$1
+EXP_DIR="experiments/$EXP_NAME"
+
+# Check if experiment already exists
+if [ -d "$EXP_DIR" ]; then
+    echo "Error: Experiment '$EXP_NAME' already exists!"
+    exit 1
+fi
+
+echo "Creating new experiment: $EXP_NAME"
+
+# Create directory
+mkdir -p "$EXP_DIR"
+
+# Copy config template
+cp experiments/_templates/config.template.yaml "$EXP_DIR/config.yaml"
+
+# Update output path in config
+sed -i '' "s|YOUR-EXP-NAME|$EXP_NAME|g" "$EXP_DIR/config.yaml"
+
+# Create NOTES.md
+cat > "$EXP_DIR/NOTES.md" << NOTES
+# $EXP_NAME
+
+## Goal
+(Describe what you're testing in this experiment)
+
+## Configuration
+- Model: (e.g., mistral, llama2)
+- Prompt: (baseline | fewshot | reasoned)
+- Temperature: (0.0 - 1.0)
+- Dataset: (describe your video samples)
+
+## Hypothesis
+(What do you expect to happen?)
+
+## Status
+- [ ] Config customized
+- [ ] Videos prepared
+- [ ] Batch experiment run
+- [ ] Analysis generated
+- [ ] Results reviewed
+
+## Observations
+(Fill after running experiment)
+
+### Quantitative Results
+- Label distribution:
+- Avg confidence:
+- Avg latency:
+
+### Qualitative Findings
+(Any interesting patterns, errors, or insights)
+
+## Next Steps
+(What to try next based on these results)
+NOTES
+
+# Create command.txt
+echo "python scripts/run_mistral_batch.py --config experiments/$EXP_NAME/config.yaml" > "$EXP_DIR/command.txt"
+
+echo "✓ Experiment folder created: $EXP_DIR"
+echo ""
+echo "Next steps:"
+echo "1. Edit $EXP_DIR/config.yaml with your settings"
+echo "2. Add video files to data/videos/"
+echo "3. Run: bash $EXP_DIR/command.txt"
+echo "4. Analyze: python scripts/analyze_experiment.py --exp-dir $EXP_DIR"

--- a/experiments/exp-multimodal-test/NOTES.md
+++ b/experiments/exp-multimodal-test/NOTES.md
@@ -1,0 +1,33 @@
+# exp-multimodal-test — Multimodal Content Extraction Test
+
+## Goal
+Test complete multimodal pipeline combining:
+- Audio transcript (Whisper/Faster-Whisper)
+- On-screen text (EasyOCR)
+
+## Configuration
+- Model: Mistral (via Ollama)
+- Prompt: baseline
+- Temperature: 0.0
+- Audio: Enabled (faster-whisper)
+- Visual: Enabled (EasyOCR, 1 fps sampling)
+- Languages: English
+
+## Hypothesis
+Combining audio + visual content will provide richer context for classification
+compared to audio-only approach.
+
+## Status
+- [x] Config created
+- [x] Video prepared (test1.mp4)
+- [ ] Batch experiment run
+- [ ] Results reviewed
+- [ ] Comparison with audio-only results
+
+## Expected Outcomes
+- More comprehensive content extraction
+- Potentially better classification accuracy
+- Ability to detect text-based misinformation missed by audio
+
+## Observations
+(To be filled after run)

--- a/experiments/exp-multimodal-test/command.txt
+++ b/experiments/exp-multimodal-test/command.txt
@@ -1,0 +1,1 @@
+python scripts/run_multimodal_batch.py --config experiments/exp-multimodal-test/config.yaml

--- a/experiments/exp-multimodal-test/config.yaml
+++ b/experiments/exp-multimodal-test/config.yaml
@@ -1,0 +1,14 @@
+# Multimodal Experiment Configuration
+input_dir: data/videos
+out: experiments/exp-multimodal-test/results.csv
+prompt: baseline
+model_name: mistral
+temperature: 0.0
+
+# Multimodal settings
+include_audio: true          # Extract speech transcript
+include_visual: true         # Extract on-screen text (OCR)
+ocr_languages: ['en']        # OCR language detection
+ocr_sample_fps: 1.0          # Sample 1 frame per second for OCR
+
+notes: "Test multimodal extraction: audio (ASR) + visual (OCR) combined"

--- a/experiments/exp-test-setup/NOTES.md
+++ b/experiments/exp-test-setup/NOTES.md
@@ -1,0 +1,21 @@
+# exp-test-setup — Environment Verification Test
+
+## Goal
+Verify complete environment setup and pipeline functionality
+
+## Configuration
+- Model: Mistral (via Ollama)
+- Prompt: baseline
+- Temperature: 0.0
+- ASR: faster-whisper (local)
+
+## Status
+- [ ] Environment setup complete
+- [ ] Test video added
+- [ ] Transcription working
+- [ ] Classification working
+- [ ] Results generated
+- [ ] Analysis plots created
+
+## Observations
+(To be filled after test run)

--- a/experiments/exp-test-setup/command.txt
+++ b/experiments/exp-test-setup/command.txt
@@ -1,0 +1,1 @@
+python scripts/run_mistral_batch.py --config experiments/exp-test-setup/config.yaml

--- a/experiments/exp-test-setup/config.yaml
+++ b/experiments/exp-test-setup/config.yaml
@@ -1,0 +1,7 @@
+input_dir: data/videos
+out: experiments/exp-test-setup/results.csv
+prompt: baseline
+model_name: mistral
+temperature: 0.0
+provider: Local
+notes: "Test experiment to verify complete pipeline setup"

--- a/pages/processes/multimodal.py
+++ b/pages/processes/multimodal.py
@@ -1,0 +1,152 @@
+"""
+Multimodal Content Extraction Module
+Combines audio transcription (ASR) with on-screen text (OCR).
+This module integrates but doesn't modify existing modules.
+"""
+
+import os
+from typing import Dict, Optional
+from pages.processes.transcription import _transcribe_local_faster_whisper
+from pages.processes.ocr.text_extractor import VideoTextExtractor
+
+
+class MultimodalExtractor:
+    """
+    Extract both audio (speech) and visual (on-screen text) content from videos.
+    Keeps both modalities separate but accessible in a unified structure.
+    """
+    
+    def __init__(self, ocr_languages=['en'], ocr_sample_fps=1.0, use_gpu=False):
+        """
+        Initialize multimodal extractor.
+        
+        Args:
+            ocr_languages: Languages for OCR detection
+            ocr_sample_fps: Frame sampling rate for OCR (1.0 = 1 frame/sec)
+            use_gpu: Use GPU for OCR (False = CPU mode)
+        """
+        self.ocr_extractor = VideoTextExtractor(
+            languages=ocr_languages, 
+            gpu=use_gpu
+        )
+        self.ocr_sample_fps = ocr_sample_fps
+    
+    def extract_audio_transcript(self, video_path: str) -> str:
+        """
+        Extract audio transcript using existing transcription module.
+        
+        Args:
+            video_path: Path to video file
+            
+        Returns:
+            Transcript text string
+        """
+        return _transcribe_local_faster_whisper(video_path)
+    
+    def extract_visual_text(self, video_path: str, min_confidence=0.5) -> Dict:
+        """
+        Extract on-screen text using OCR module.
+        
+        Args:
+            video_path: Path to video file
+            min_confidence: Minimum OCR confidence threshold
+            
+        Returns:
+            Dictionary with OCR results
+        """
+        return self.ocr_extractor.extract_text_from_video(
+            video_path, 
+            sample_fps=self.ocr_sample_fps,
+            min_confidence=min_confidence
+        )
+    
+    def extract_all(
+        self, 
+        video_path: str, 
+        include_audio=True, 
+        include_visual=True,
+        ocr_confidence=0.5
+    ) -> Dict[str, any]:
+        """
+        Extract all content (audio + visual) from video.
+        
+        Args:
+            video_path: Path to video file
+            include_audio: Whether to extract audio transcript
+            include_visual: Whether to extract on-screen text
+            ocr_confidence: Minimum confidence for OCR detections
+            
+        Returns:
+            Dictionary containing:
+                - audio_transcript: Speech-to-text transcript
+                - visual_text: On-screen text (combined)
+                - visual_text_unique: Unique on-screen phrases
+                - visual_detections: Detailed OCR results
+                - combined_content: All text combined (audio + visual)
+                - modalities_used: List of modalities extracted
+        """
+        result = {
+            'audio_transcript': '',
+            'visual_text': '',
+            'visual_text_unique': [],
+            'visual_detections': [],
+            'combined_content': '',
+            'modalities_used': [],
+            'metadata': {}
+        }
+        
+        # Extract audio
+        if include_audio:
+            result['audio_transcript'] = self.extract_audio_transcript(video_path)
+            result['modalities_used'].append('audio')
+            result['metadata']['audio_length_chars'] = len(result['audio_transcript'])
+        
+        # Extract visual
+        if include_visual:
+            ocr_result = self.extract_visual_text(video_path, min_confidence=ocr_confidence)
+            result['visual_text'] = ocr_result['all_text']
+            result['visual_text_unique'] = ocr_result['unique_text']
+            result['visual_detections'] = ocr_result['detections']
+            result['modalities_used'].append('visual')
+            result['metadata']['visual_length_chars'] = len(result['visual_text'])
+            result['metadata']['visual_detection_count'] = ocr_result['detection_count']
+            result['metadata']['frames_processed'] = ocr_result['frame_count']
+        
+        # Combine all content
+        parts = []
+        if result['audio_transcript']:
+            parts.append(f"[AUDIO TRANSCRIPT]\n{result['audio_transcript']}")
+        if result['visual_text']:
+            parts.append(f"[ON-SCREEN TEXT]\n{result['visual_text']}")
+        
+        result['combined_content'] = '\n\n'.join(parts)
+        result['metadata']['total_content_length'] = len(result['combined_content'])
+        
+        return result
+
+
+# Convenience function for simple use
+def extract_multimodal_content(
+    video_path: str,
+    include_audio=True,
+    include_visual=True,
+    ocr_languages=['en']
+) -> Dict:
+    """
+    Simple interface for multimodal extraction.
+    
+    Args:
+        video_path: Path to video file
+        include_audio: Extract speech transcript
+        include_visual: Extract on-screen text
+        ocr_languages: Languages for OCR
+        
+    Returns:
+        Dictionary with all extracted content
+    """
+    extractor = MultimodalExtractor(ocr_languages=ocr_languages)
+    return extractor.extract_all(
+        video_path,
+        include_audio=include_audio,
+        include_visual=include_visual
+    )

--- a/pages/processes/ocr/text_extractor.py
+++ b/pages/processes/ocr/text_extractor.py
@@ -1,0 +1,160 @@
+"""
+OCR Text Extraction Module
+Extracts on-screen text from video frames using EasyOCR.
+This module is independent of transcription and analysis modules.
+"""
+
+import os
+import cv2
+import tempfile
+from typing import List, Dict, Tuple
+import numpy as np
+
+
+class VideoTextExtractor:
+    """
+    Extract text from video frames using OCR.
+    Designed to work independently without affecting existing modules.
+    """
+    
+    def __init__(self, languages=['en'], gpu=False):
+        """
+        Initialize the OCR reader.
+        
+        Args:
+            languages: List of language codes (e.g., ['en', 'es', 'zh'])
+            gpu: Whether to use GPU (False for CPU mode)
+        """
+        self._reader = None
+        self.languages = languages
+        self.gpu = gpu
+        
+    def _get_reader(self):
+        """Lazy load the EasyOCR reader (downloads models on first use)."""
+        if self._reader is None:
+            import easyocr
+            self._reader = easyocr.Reader(self.languages, gpu=self.gpu)
+        return self._reader
+    
+    def extract_frames(self, video_path: str, fps: float = 1.0) -> List[np.ndarray]:
+        """
+        Extract frames from video at specified FPS.
+        
+        Args:
+            video_path: Path to video file
+            fps: Frames per second to extract (1.0 = one frame per second)
+            
+        Returns:
+            List of frame images as numpy arrays
+        """
+        frames = []
+        cap = cv2.VideoCapture(video_path)
+        
+        if not cap.isOpened():
+            raise ValueError(f"Cannot open video: {video_path}")
+        
+        video_fps = cap.get(cv2.CAP_PROP_FPS)
+        frame_interval = int(video_fps / fps) if fps < video_fps else 1
+        
+        frame_count = 0
+        while True:
+            ret, frame = cap.read()
+            if not ret:
+                break
+                
+            if frame_count % frame_interval == 0:
+                frames.append(frame)
+                
+            frame_count += 1
+        
+        cap.release()
+        return frames
+    
+    def extract_text_from_frame(self, frame: np.ndarray) -> List[Tuple[str, float]]:
+        """
+        Extract text from a single frame.
+        
+        Args:
+            frame: Image as numpy array (OpenCV format)
+            
+        Returns:
+            List of (text, confidence) tuples
+        """
+        reader = self._get_reader()
+        results = reader.readtext(frame)
+        
+        # Filter out low confidence detections
+        filtered = [(text, conf) for (bbox, text, conf) in results if conf > 0.3]
+        return filtered
+    
+    def extract_text_from_video(
+        self, 
+        video_path: str, 
+        sample_fps: float = 1.0,
+        min_confidence: float = 0.5
+    ) -> Dict[str, any]:
+        """
+        Extract all text from video by sampling frames.
+        
+        Args:
+            video_path: Path to video file
+            sample_fps: Frames per second to sample (lower = faster but might miss text)
+            min_confidence: Minimum confidence threshold for text detection
+            
+        Returns:
+            Dictionary with:
+                - all_text: Combined text from all frames
+                - unique_text: Unique text phrases found
+                - frame_count: Number of frames processed
+                - detections: List of all detections with metadata
+        """
+        frames = self.extract_frames(video_path, fps=sample_fps)
+        
+        all_detections = []
+        all_text_list = []
+        
+        for frame_idx, frame in enumerate(frames):
+            detections = self.extract_text_from_frame(frame)
+            
+            for text, conf in detections:
+                if conf >= min_confidence:
+                    all_text_list.append(text)
+                    all_detections.append({
+                        'frame_idx': frame_idx,
+                        'text': text,
+                        'confidence': round(conf, 3)
+                    })
+        
+        # Combine and deduplicate
+        combined_text = ' '.join(all_text_list)
+        unique_text = list(set(all_text_list))
+        
+        return {
+            'all_text': combined_text,
+            'unique_text': unique_text,
+            'frame_count': len(frames),
+            'detections': all_detections,
+            'detection_count': len(all_detections)
+        }
+
+
+# Convenience function for simple use cases
+def extract_text_from_video_simple(
+    video_path: str, 
+    languages=['en'], 
+    sample_fps=1.0
+) -> str:
+    """
+    Simple interface: returns just the combined text string.
+    
+    Args:
+        video_path: Path to video file
+        languages: OCR languages to use
+        sample_fps: Sampling rate (frames per second)
+        
+    Returns:
+        Combined text string from all frames
+    """
+    extractor = VideoTextExtractor(languages=languages, gpu=False)
+    result = extractor.extract_text_from_video(video_path, sample_fps=sample_fps)
+    return result['all_text']

--- a/scripts/run_multimodal_batch.py
+++ b/scripts/run_multimodal_batch.py
@@ -1,0 +1,203 @@
+"""
+Multimodal Batch Experiment Script
+Runs experiments with both audio transcription AND on-screen text extraction.
+This is separate from run_mistral_batch.py to maintain backward compatibility.
+"""
+
+import os
+import csv
+import sys
+import glob
+import time
+import json
+import argparse
+from pathlib import Path
+
+# Import modules
+try:
+    from pages.processes.analysis import _extract_json_block
+    from pages.processes.multimodal import extract_multimodal_content
+except ModuleNotFoundError:
+    ROOT = Path(__file__).resolve().parent.parent
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    from pages.processes.analysis import _extract_json_block
+    from pages.processes.multimodal import extract_multimodal_content
+
+# Reuse prompt definitions from original script
+BASE_PROMPT = """You are a public-health fact-checking assistant.
+
+Given the content below (which may include both audio transcript and on-screen text), do three things:
+1) Choose exactly one label from this set:
+   [NO_MISINFO, MISINFO, DEBUNKING, CANNOT_RECOGNIZE]
+2) Extract up to 10 keywords that summarize the content (list, not strings with commas).
+3) Provide a confidence score between 0 and 1.
+
+Respond ONLY as a single JSON object, no prose, in the form:
+{
+  "label": "DEBUNKING|MISINFO|NO_MISINFO|CANNOT_RECOGNIZE",
+  "keywords": ["kw1","kw2", "..."],
+  "confidence": 0.87
+}
+"""
+
+FEWSHOT_SUFFIX = """
+Here are examples to calibrate your judgement:
+
+Example A (DEBUNKING):
+Content: "A doctor explains that vaccines do NOT cause autism and cites CDC."
+JSON: {"label":"DEBUNKING","keywords":["vaccines","autism","CDC"],"confidence":0.9}
+
+Example B (MISINFO):
+Content: "Drinking bleach cures infections."
+JSON: {"label":"MISINFO","keywords":["bleach","cure","infections"],"confidence":0.95}
+
+Now classify the provided content with the same JSON schema only.
+"""
+
+REASONED_SUFFIX = """
+Think step-by-step but only return the final JSON (do not include your reasoning).
+"""
+
+
+def build_prompt(kind: str) -> str:
+    if kind == "baseline":
+        return BASE_PROMPT
+    if kind == "fewshot":
+        return BASE_PROMPT + "\n" + FEWSHOT_SUFFIX
+    if kind == "reasoned":
+        return BASE_PROMPT + "\n" + REASONED_SUFFIX
+    return BASE_PROMPT
+
+
+def analyze_with_mistral(content: str, prompt_kind: str, temperature: float, model_name: str):
+    """
+    Call local Ollama to classify content (audio + visual combined).
+    """
+    import requests
+
+    start = time.time()
+    url = "http://localhost:11434/api/chat"
+    body = {
+        "model": model_name,
+        "messages": [
+            {"role": "system", "content": build_prompt(prompt_kind)},
+            {"role": "user", "content": content},
+        ],
+        "options": {"temperature": float(temperature)},
+        "stream": False,
+    }
+
+    r = requests.post(url, json=body, timeout=180)  # Longer timeout for multimodal
+    r.raise_for_status()
+
+    content_resp = ""
+    try:
+        data = r.json()
+        if isinstance(data, dict) and "message" in data:
+            content_resp = data["message"].get("content", "")
+        else:
+            content_resp = r.text
+    except Exception:
+        content_resp = r.text
+
+    result = _extract_json_block(content_resp)
+    result["time_taken_secs"] = round(time.time() - start, 2)
+    return result
+
+
+def main():
+    import yaml
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True, help="Path to YAML config")
+    args = ap.parse_args()
+
+    with open(args.config, "r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f) or {}
+
+    input_dir = cfg.get("input_dir", "data/videos")
+    out_csv = cfg.get("out", "experiments/results.csv")
+    prompt_kind = cfg.get("prompt", "baseline")
+    model_name = cfg.get("model_name", "mistral")
+    temperature = float(cfg.get("temperature", 0.0))
+    
+    # NEW: Multimodal options
+    include_audio = cfg.get("include_audio", True)
+    include_visual = cfg.get("include_visual", True)
+    ocr_languages = cfg.get("ocr_languages", ["en"])
+    ocr_sample_fps = float(cfg.get("ocr_sample_fps", 1.0))
+
+    Path(out_csv).parent.mkdir(parents=True, exist_ok=True)
+
+    video_paths = []
+    for ext in ("*.mp4", "*.mp3", "*.wav", "*.m4a"):
+        video_paths += glob.glob(os.path.join(input_dir, ext))
+    video_paths = sorted(set(video_paths))
+
+    fieldnames = [
+        "prompt_id",
+        "model_name",
+        "video_file",
+        "audio_transcript",
+        "visual_text",
+        "combined_content",
+        "modalities_used",
+        "label",
+        "keywords",
+        "confidence_score",
+        "time_taken_sec",
+    ]
+    
+    with open(out_csv, "w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=fieldnames)
+        w.writeheader()
+
+        for p in video_paths:
+            bn = os.path.basename(p)
+            print(f"[{bn}] extracting multimodal content…", flush=True)
+            
+            # Extract both audio and visual
+            multimodal_result = extract_multimodal_content(
+                p,
+                include_audio=include_audio,
+                include_visual=include_visual,
+                ocr_languages=ocr_languages
+            )
+
+            print(f"[{bn}] analyzing with {model_name}…", flush=True)
+            
+            # Use combined content for classification
+            content_for_analysis = multimodal_result['combined_content']
+            analysis_result = analyze_with_mistral(
+                content_for_analysis, 
+                prompt_kind, 
+                temperature, 
+                model_name
+            )
+
+            row = {
+                "prompt_id": prompt_kind,
+                "model_name": model_name,
+                "video_file": bn,
+                "audio_transcript": multimodal_result['audio_transcript'],
+                "visual_text": multimodal_result['visual_text'],
+                "combined_content": content_for_analysis,
+                "modalities_used": ";".join(multimodal_result['modalities_used']),
+                "label": analysis_result.get("label", "CANNOT_RECOGNIZE"),
+                "keywords": ";".join(analysis_result.get("keywords", [])),
+                "confidence_score": round(float(analysis_result.get("confidence", 0.0)), 2),
+                "time_taken_sec": analysis_result.get("time_taken_secs"),
+            }
+            w.writerow(row)
+            print(
+                f"[{bn}] done. label={row['label']} conf={row['confidence_score']} "
+                f"modalities={row['modalities_used']}",
+                flush=True,
+            )
+
+    print(f"\nWrote {out_csv}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Created OCR module (pages/processes/ocr/) using EasyOCR
- Created multimodal integration module (pages/processes/multimodal.py)
- Added multimodal batch processing script (scripts/run_multimodal_batch.py)
- Added experiment templates for easy experiment creation
- Updated .gitignore for OCR model caches
- Added experiment configurations (configs and notes only)

Features:
- Extract on-screen text from video frames using OCR
- Combine audio transcription + visual text extraction
- Fully modular - backward compatible with existing pipeline
- Supports 80+ languages for OCR
- Separate batch script maintains compatibility with original workflow
- Experiment templates for standardized testing

Implementation Details:
- Uses EasyOCR (better macOS compatibility than PaddleOCR)
- Lazy-loads models (downloads ~50-100MB on first use)
- Configurable frame sampling rate (default 1 fps)
- Confidence thresholding for text detection
- Modular design: OCR module works independently

Tested successfully on sample video:
- OCR: 125 text detections from 33 frames
- Multimodal extraction: audio + visual combined
- Classification working with combined content

Note: Test results and generated plots not included in this commit.