### PR TITLE
Add multi-language support for Spanish videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,36 @@ It combines:
 
 - **Experimentation framework** for systematic evaluation of prompts, models, and settings.
 
+- **Multi-language support** for both audio transcription and on-screen text extraction.
 
+
+
+## Language Support
+
+The tool now supports **multiple languages** for comprehensive video analysis:
+
+### Audio Transcription (Whisper)
+- **Automatic language detection** – Whisper automatically detects the spoken language
+- Supports **99+ languages** including English, Spanish, French, German, Chinese, and more
+- No configuration needed – works out of the box for any language
+
+### On-Screen Text (OCR)
+- **Default languages**: English and Spanish (`['en', 'es']`)
+- Powered by EasyOCR for accurate text detection
+- Can detect multiple languages in the same video
+- Easily extensible – add more language codes as needed (e.g., `['en', 'es', 'zh']` for Chinese)
+
+### Usage
+For most users, **no changes are required** – the system will automatically:
+1. Detect and transcribe audio in any language (via Whisper)
+2. Extract on-screen text in English and Spanish (via EasyOCR)
+
+To add more OCR languages, update `ocr_languages` in your experiment config:
+```yaml
+ocr_languages: ['en', 'es', 'fr']  # Add French
+```
+
+---
 
 >  Important: We have **not changed the original structure** of the app.
 

--- a/experiments/_templates/config.template.yaml
+++ b/experiments/_templates/config.template.yaml
@@ -18,3 +18,13 @@ notes: "Brief description of experiment goals"
 # - 0.0: Reproducible, deterministic (recommended for experiments)
 # - 0.3-0.7: Balanced creativity
 # - 1.0+: More creative but less consistent
+
+# Multimodal Settings (for multimodal batch experiments):
+include_audio: true              # Extract speech transcript (Whisper auto-detects language)
+include_visual: true             # Extract on-screen text using OCR
+ocr_languages: ['en', 'es']      # OCR language detection (English + Spanish)
+ocr_sample_fps: 1.0              # Frame sampling rate for OCR (1.0 = 1 frame/second)
+
+# Language Support:
+# - Audio: Whisper automatically detects language (supports 99+ languages including English and Spanish)
+# - OCR: EasyOCR supports multiple languages; add language codes as needed (e.g., ['en', 'es', 'zh'])

--- a/pages/processes/multimodal.py
+++ b/pages/processes/multimodal.py
@@ -16,7 +16,7 @@ class MultimodalExtractor:
     Keeps both modalities separate but accessible in a unified structure.
     """
     
-    def __init__(self, ocr_languages=['en'], ocr_sample_fps=1.0, use_gpu=False):
+    def __init__(self, ocr_languages=['en', 'es'], ocr_sample_fps=1.0, use_gpu=False):
         """
         Initialize multimodal extractor.
         
@@ -130,7 +130,7 @@ def extract_multimodal_content(
     video_path: str,
     include_audio=True,
     include_visual=True,
-    ocr_languages=['en']
+    ocr_languages=['en', 'es']
 ) -> Dict:
     """
     Simple interface for multimodal extraction.

--- a/pages/processes/ocr/text_extractor.py
+++ b/pages/processes/ocr/text_extractor.py
@@ -17,7 +17,7 @@ class VideoTextExtractor:
     Designed to work independently without affecting existing modules.
     """
     
-    def __init__(self, languages=['en'], gpu=False):
+    def __init__(self, languages=['en', 'es'], gpu=False):
         """
         Initialize the OCR reader.
         
@@ -141,7 +141,7 @@ class VideoTextExtractor:
 # Convenience function for simple use cases
 def extract_text_from_video_simple(
     video_path: str, 
-    languages=['en'], 
+    languages=['en', 'es'], 
     sample_fps=1.0
 ) -> str:
     """

--- a/scripts/run_multimodal_batch.py
+++ b/scripts/run_multimodal_batch.py
@@ -125,7 +125,7 @@ def main():
     # NEW: Multimodal options
     include_audio = cfg.get("include_audio", True)
     include_visual = cfg.get("include_visual", True)
-    ocr_languages = cfg.get("ocr_languages", ["en"])
+    ocr_languages = cfg.get("ocr_languages", ["en", "es"])
     ocr_sample_fps = float(cfg.get("ocr_sample_fps", 1.0))
 
     Path(out_csv).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
- Enable Spanish OCR detection alongside English in all modules
- Update default ocr_languages to ['en', 'es'] across:
  - pages/processes/multimodal.py
  - pages/processes/ocr/text_extractor.py
  - scripts/run_multimodal_batch.py
- Update config template with bilingual settings
- Add comprehensive language support documentation to README
- Whisper auto-detects audio language
- EasyOCR now detects both English and Spanish on-screen text
